### PR TITLE
Add random variation to timer and timer nodes

### DIFF
--- a/Assets/Example/Player.cs
+++ b/Assets/Example/Player.cs
@@ -26,14 +26,14 @@ public class Player : MonoBehaviour
         tree = new BehaviourTree("ExampleTree");
         blackboard = new Blackboard();
 
-        Service exampleService = new Service("ExampleBB", 2f, ExampleBlackboardService, false, true);
+        Service exampleService = new Service("ExampleBB", 2f, 0.25f, ExampleBlackboardService, false, true);
 
         Action move1 = new Action("Move1", () => Move(point1.position));
         Action move2 = new Action("Move2", () => Move(point2.position));
         Action move3 = new Action("Move3", () => Move(point3.position));
         Action move4 = new Action("Move4", () => Move(point4.position));
 
-        Cooldown limiter = new Cooldown("Limiter", 5.0f, true, new Action(LimitExample));
+        Cooldown limiter = new Cooldown("Limiter", 5.0f, 0.1f, true, new Action(LimitExample));
         RandomSelector moveSelector = new RandomSelector("MoveSelector", move1, move2, move3, move4);
 
         Sequence sequence = new Sequence("Sequence", moveSelector, limiter);

--- a/Assets/PineBT/Blackboard.cs
+++ b/Assets/PineBT/Blackboard.cs
@@ -42,14 +42,16 @@ namespace PineBT
 
         /// <summary>
         /// Constructs a Blackboard with a default name.
+        /// Random variation defaults to 0.
         /// </summary>
-        public Blackboard(float timerRandomVariation = 0.1f) : this("Blackboard", timerRandomVariation)
+        public Blackboard(float timerRandomVariation = 0f) : this("Blackboard", timerRandomVariation)
         {}
 
         /// <summary>
         /// Constructs a Blackboard with a custom name.
+        /// Random variation defaults to 0.
         /// </summary>
-        public Blackboard(string name, float timerRandomVariation = 0.1f)
+        public Blackboard(string name, float timerRandomVariation = 0f)
         {
             this.name = name;
             this.timerRandomVariation = timerRandomVariation;
@@ -57,14 +59,16 @@ namespace PineBT
 
         /// <summary>
         /// Constructs a Blackboard with a parent.
+        /// Random variation defaults to 0.
         /// </summary>
-        public Blackboard(Blackboard parent, float timerRandomVariation = 0.1f) : this("Blackboard", parent, timerRandomVariation)
+        public Blackboard(Blackboard parent, float timerRandomVariation = 0f) : this("Blackboard", parent, timerRandomVariation)
         {}
 
         /// <summary>
         /// Constructs a Blackboard with a custom name and parent.
+        /// Random variation defaults to 0.
         /// </summary>
-        public Blackboard(string name, Blackboard parent, float timerRandomVariation = 0.1f)
+        public Blackboard(string name, Blackboard parent, float timerRandomVariation = 0f)
         {
             this.name = name;
             this.parent = parent;

--- a/Assets/PineBT/Blackboard.cs
+++ b/Assets/PineBT/Blackboard.cs
@@ -36,32 +36,39 @@ namespace PineBT
         private PineTreeManager treeManager;
 
         /// <summary>
+        /// The amount of random variation added to the blackboard's TriggerListener's timer.
+        /// </summary>
+        private float timerRandomVariation;
+
+        /// <summary>
         /// Constructs a Blackboard with a default name.
         /// </summary>
-        public Blackboard() : this("Blackboard")
+        public Blackboard(float timerRandomVariation = 0.1f) : this("Blackboard", timerRandomVariation)
         {}
 
         /// <summary>
         /// Constructs a Blackboard with a custom name.
         /// </summary>
-        public Blackboard(string name)
+        public Blackboard(string name, float timerRandomVariation = 0.1f)
         {
             this.name = name;
+            this.timerRandomVariation = timerRandomVariation;
         }
 
         /// <summary>
         /// Constructs a Blackboard with a parent.
         /// </summary>
-        public Blackboard(Blackboard parent) : this("Blackboard", parent)
+        public Blackboard(Blackboard parent, float timerRandomVariation = 0.1f) : this("Blackboard", parent, timerRandomVariation)
         {}
 
         /// <summary>
         /// Constructs a Blackboard with a custom name and parent.
         /// </summary>
-        public Blackboard(string name, Blackboard parent)
+        public Blackboard(string name, Blackboard parent, float timerRandomVariation = 0.1f)
         {
             this.name = name;
             this.parent = parent;
+            this.timerRandomVariation = timerRandomVariation;
         }
 
         /// <summary>
@@ -199,7 +206,7 @@ namespace PineBT
             if (notifications.Count == 0)
                 return;
 
-            treeManager.RegisterTimer(0, 1, TriggerListeners);
+            treeManager.RegisterTimer(0, timerRandomVariation, 1, TriggerListeners);
         }
 
         /// <summary>

--- a/Assets/PineBT/Decorators/Cooldown.cs
+++ b/Assets/PineBT/Decorators/Cooldown.cs
@@ -35,6 +35,10 @@
         /// The <see cref="State"/> to return when the Cooldown is executed during the cooldown period. Defaults to <see cref="State.SUCCESS"/>.
         /// </summary>
         private State coolDownReturnState = State.SUCCESS;
+        /// <summary>
+        /// The amount of random variation added to the cooldown time.
+        /// </summary>
+        private float timerRandomVariation;
 
         // Is is the cooldown period over and can the Child be executed.
         private bool canExecute = true;
@@ -50,9 +54,10 @@
         /// </summary>
         /// <param name="name">Name of the Cooldown Node.</param>
         /// <param name="coolDownTime">Length of the cooldown period.</param>
+        /// <param name="randomVariation">The amount of random variation added to the cooldown time.</param>
         /// <param name="coolDownReturnState">State to return during cooldown period.</param>
-        public Cooldown(string name, float coolDownTime, State coolDownReturnState) 
-        : this(name, coolDownTime, false)
+        public Cooldown(string name, float coolDownTime, float randomVariation, State coolDownReturnState) 
+        : this(name, coolDownTime, randomVariation, false)
         {
             this.coolDownReturnState = coolDownReturnState;
         }
@@ -67,14 +72,16 @@
         /// </summary>
         /// <param name="name">Name of the Cooldown Node.</param>
         /// <param name="coolDownTime">Length of the cooldown period.</param>
+        /// <param name="randomVariation">The amount of random variation added to the cooldown time.</param>
         /// <param name="returnPreviousChildState">Whether to return the child's <see cref="State"/></param>
-        public Cooldown(string name, float coolDownTime, bool returnPreviousChildState) 
+        public Cooldown(string name, float coolDownTime, float randomVariation, bool returnPreviousChildState) 
         : base(name)
         {
             this.coolDownTime = coolDownTime;
             this.returnPreviousChildState = returnPreviousChildState;
             this.startCooldownAfterChild = false;
             this.cancelCooldownOnFailure = false;
+            this.timerRandomVariation = randomVariation;
             this.treeManager = PineTreeUnityContext.Instance().TreeManager;
         }
 
@@ -87,10 +94,11 @@
         /// </summary>
         /// <param name="name">Name of the Cooldown Node.</param>
         /// <param name="coolDownTime">Length of the cooldown period.</param>
+        /// <param name="randomVariation">The amount of random variation added to the cooldown time.</param>
         /// <param name="coolDownReturnState">State to return during cooldown period.</param>
         /// <param name="child">The child of the Cooldown decorator.</param>
-        public Cooldown(string name, float coolDownTime, State coolDownReturnState, Node child) 
-        : this(name, coolDownTime, false, child)
+        public Cooldown(string name, float coolDownTime, float randomVariation, State coolDownReturnState, Node child) 
+        : this(name, coolDownTime, randomVariation, false, child)
         {
             this.coolDownReturnState = coolDownReturnState;
         }
@@ -105,15 +113,17 @@
         /// </summary>
         /// <param name="name">Name of the Cooldown Node.</param>
         /// <param name="coolDownTime">Length of the cooldown period.</param>
+        /// <param name="randomVariation">The amount of random variation added to the cooldown time.</param>
         /// <param name="returnPreviousChildState">Whether to return the child's <see cref="State"/></param>
         /// <param name="child">The child of the Cooldown decorator.</param>
-        public Cooldown(string name, float coolDownTime, bool returnPreviousChildState, Node child) 
+        public Cooldown(string name, float coolDownTime, float randomVariation, bool returnPreviousChildState, Node child) 
         : base(name, child)
         {
             this.coolDownTime = coolDownTime;
             this.returnPreviousChildState = returnPreviousChildState;
             this.startCooldownAfterChild = false;
             this.cancelCooldownOnFailure = false;
+            this.timerRandomVariation = randomVariation;
             this.treeManager = PineTreeUnityContext.Instance().TreeManager;
         }
 
@@ -122,12 +132,13 @@
         /// </summary>
         /// <param name="name">Name of the Cooldown Node.</param>
         /// <param name="coolDownTime">Length of the cooldown period.</param>
+        /// <param name="randomVariation">The amount of random variation added to the cooldown time.</param>
         /// <param name="coolDownReturnState">State to return during cooldown period.</param>
         /// <param name="startCooldownAfterChild">
         /// Start the cooldown timer after the child has executed and returned a <see cref="State"/>.</param>
         /// <param name="cancelCooldownOnFailure">Cancel the cooldown period if the child's execution is a <see cref="State.FAILURE"/>.</param>
-        public Cooldown(string name, float coolDownTime, State coolDownReturnState, bool startCooldownAfterChild, bool cancelCooldownOnFailure) 
-        : this(name, coolDownTime, false, startCooldownAfterChild, cancelCooldownOnFailure)
+        public Cooldown(string name, float coolDownTime, float randomVariation, State coolDownReturnState, bool startCooldownAfterChild, bool cancelCooldownOnFailure) 
+        : this(name, coolDownTime, randomVariation, false, startCooldownAfterChild, cancelCooldownOnFailure)
         {
             this.coolDownReturnState = coolDownReturnState;
         }
@@ -138,17 +149,19 @@
         /// </summary>
         /// <param name="name">Name of the Cooldown Node.</param>
         /// <param name="coolDownTime">Length of the cooldown period.</param>
+        /// <param name="randomVariation">The amount of random variation added to the cooldown time.</param>
         /// <param name="returnPreviousChildState">Whether to return the child's <see cref="State"/></param>
         /// <param name="startCooldownAfterChild">
         /// Start the cooldown timer after the child has executed and returned a <see cref="State"/>.</param>
         /// <param name="cancelCooldownOnFailure">Cancel the cooldown period if the child's execution is a <see cref="State.FAILURE"/>.</param>
-        public Cooldown(string name, float coolDownTime, bool returnPreviousChildState, bool startCooldownAfterChild, bool cancelCooldownOnFailure) 
+        public Cooldown(string name, float coolDownTime, float randomVariation, bool returnPreviousChildState, bool startCooldownAfterChild, bool cancelCooldownOnFailure) 
         : base(name)
         {
             this.coolDownTime = coolDownTime;
             this.returnPreviousChildState = returnPreviousChildState;
             this.startCooldownAfterChild = startCooldownAfterChild;
             this.cancelCooldownOnFailure = cancelCooldownOnFailure;
+            this.timerRandomVariation = randomVariation;
             this.treeManager = PineTreeUnityContext.Instance().TreeManager;
         }
 
@@ -157,13 +170,14 @@
         /// </summary>
         /// <param name="name">Name of the Cooldown Node.</param>
         /// <param name="coolDownTime">Length of the cooldown period.</param>
+        /// <param name="randomVariation">The amount of random variation added to the cooldown time.</param>
         /// <param name="coolDownReturnState">State to return during cooldown period.</param>
         /// <param name="startCooldownAfterChild">
         /// Start the cooldown timer after the child has executed and returned a <see cref="State"/>.</param>
         /// <param name="cancelCooldownOnFailure">Cancel the cooldown period if the child's execution is a <see cref="State.FAILURE"/>.</param>
         /// <param name="child">The child of the Cooldown decorator.</param>
-        public Cooldown(string name, float coolDownTime, State coolDownReturnState, bool startCooldownAfterChild, bool cancelCooldownOnFailure, Node child) 
-        : this(name, coolDownTime, false, startCooldownAfterChild, cancelCooldownOnFailure, child)
+        public Cooldown(string name, float coolDownTime, float randomVariation, State coolDownReturnState, bool startCooldownAfterChild, bool cancelCooldownOnFailure, Node child) 
+        : this(name, coolDownTime, randomVariation, false, startCooldownAfterChild, cancelCooldownOnFailure, child)
         {
             this.coolDownReturnState = coolDownReturnState;
         }
@@ -174,18 +188,20 @@
         /// </summary>
         /// <param name="name">Name of the Cooldown Node.</param>
         /// <param name="coolDownTime">Length of the cooldown period.</param>
+        /// <param name="randomVariation">The amount of random variation added to the cooldown time.</param>
         /// <param name="returnPreviousChildState">Whether to return the child's <see cref="State"/></param>
         /// <param name="startCooldownAfterChild">
         /// Start the cooldown timer after the child has executed and returned a <see cref="State"/>.</param>
         /// <param name="cancelCooldownOnFailure">Cancel the cooldown period if the child's execution is a <see cref="State.FAILURE"/>.</param>
         /// <param name="child">The child of the Cooldown decorator.</param>
-        public Cooldown(string name, float coolDownTime, bool returnPreviousChildState, bool startCooldownAfterChild, bool cancelCooldownOnFailure, Node child) 
+        public Cooldown(string name, float coolDownTime, float randomVariation, bool returnPreviousChildState, bool startCooldownAfterChild, bool cancelCooldownOnFailure, Node child) 
         : base(name, child)
         {
             this.coolDownTime = coolDownTime;
             this.returnPreviousChildState = returnPreviousChildState;
             this.startCooldownAfterChild = startCooldownAfterChild;
             this.cancelCooldownOnFailure = cancelCooldownOnFailure;
+            this.timerRandomVariation = randomVariation;
             this.treeManager = PineTreeUnityContext.Instance().TreeManager;
         }
 
@@ -203,7 +219,7 @@
                 {
                     // Reset canExecute to false for next cooldown period and start timer
                     canExecute = false;
-                    treeManager.RegisterTimer(this.coolDownTime, 1, OnCooldownTimeReached);
+                    treeManager.RegisterTimer(this.coolDownTime, timerRandomVariation, 1, OnCooldownTimeReached);
                 }
                 // Run Decorator base execute
                 base.Execute();
@@ -257,7 +273,7 @@
             if (startCooldownAfterChild && !(state == State.FAILURE && cancelCooldownOnFailure))
             {
                 canExecute = false;
-                treeManager.RegisterTimer(coolDownTime, 1, OnCooldownTimeReached);
+                treeManager.RegisterTimer(coolDownTime, timerRandomVariation, 1, OnCooldownTimeReached);
             }
         }
 

--- a/Assets/PineBT/Decorators/Service.cs
+++ b/Assets/PineBT/Decorators/Service.cs
@@ -29,6 +29,10 @@ namespace PineBT
         /// Defaults to false, meaning if the branch the Service is on isn't receiving Update calls, the Service will not execute.
         /// </summary>
         private bool executeContinuously = false;
+        /// <summary>
+        /// The amount of random variation added to the service's timer.
+        /// </summary>
+        private float timerRandomVariation = 0f;
 
         // Has the service done an initial execution on its first Start call
         private bool initialExecution = false;
@@ -67,11 +71,26 @@ namespace PineBT
         /// Defaults to true, meaning the Service will perform another execution independently of the current time between intervals.</param>
         /// <param name="executeContinuously">Whether the service should continue to execute even if its branch isn't running.
         /// Defaults to false, meaning if the branch the Service is on isn't receiving Update calls, the Service will not execute.</param>
-        public Service(
-            string name, float interval, System.Action service, bool executeOnEachStart, bool executeContinuously) 
-            : base(name)
+        public Service(string name, float interval, System.Action service, bool executeOnEachStart, bool executeContinuously) 
+        : this(name, interval, 0f, service, executeOnEachStart, executeContinuously)
+        {}
+
+        /// <summary>
+        /// Named Service thats executes at the interval rate with random variation.
+        /// </summary>
+        /// <param name="name">Name of the Service</param>
+        /// <param name="interval">The time frequency the Service should be executed. Example: 0.150f = 150 milliseconds.</param>
+        /// <param name="randomVariation">Time randomly added to the interval.</param>
+        /// <param name="service">The function to be executed.</param>
+        /// <param name="executeOnEachStart">Whether the service should additionally execute on each <see cref="Start"/> call.
+        /// Defaults to true, meaning the Service will perform another execution independently of the current time between intervals.</param>
+        /// <param name="executeContinuously">Whether the service should continue to execute even if its branch isn't running.
+        /// Defaults to false, meaning if the branch the Service is on isn't receiving Update calls, the Service will not execute.</param>
+        public Service(string name, float interval, float randomVariation, System.Action service, bool executeOnEachStart, bool executeContinuously) 
+        : base(name)
         {
             this.interval = interval;
+            this.timerRandomVariation = randomVariation;
             this.serviceFunction = service;
             this.executeOnEachStart = executeOnEachStart;
             this.executeContinuously = executeContinuously;
@@ -88,11 +107,27 @@ namespace PineBT
         /// <param name="executeContinuously">Whether the service should continue to execute even if its branch isn't running.
         /// Defaults to false, meaning if the branch the Service is on isn't receiving Update calls, the Service will not execute.</param>
         /// <param name="child">The Decorator's child Node.</param>
-        public Service(
-            string name, float interval, System.Action service, bool executeOnEachStart, bool executeContinuously, Node child) 
-            : base(name, child)
+        public Service(string name, float interval, System.Action service, bool executeOnEachStart, bool executeContinuously, Node child) 
+        : this(name, interval, 0f, service, executeOnEachStart, executeContinuously, child)
+        {}
+
+        /// <summary>
+        /// Named Service thats executes at the interval rate.
+        /// </summary>
+        /// <param name="name">Name of the Service</param>
+        /// <param name="interval">The time frequency the Service should be executed. Example: 0.150f = 150 milliseconds.</param>
+        /// <param name="randomVariation">Time randomly added to the interval.</param>
+        /// <param name="service">The function to be executed.</param>
+        /// <param name="executeOnEachStart">Whether the service should additionally execute on each <see cref="Start"/> call.
+        /// Defaults to true, meaning the Service will perform another execution independently of the current time between intervals.</param>
+        /// <param name="executeContinuously">Whether the service should continue to execute even if its branch isn't running.
+        /// Defaults to false, meaning if the branch the Service is on isn't receiving Update calls, the Service will not execute.</param>
+        /// <param name="child">The Decorator's child Node.</param>
+        public Service(string name, float interval, float randomVariation, System.Action service, bool executeOnEachStart, bool executeContinuously, Node child) 
+        : base(name, child)
         {
             this.interval = interval;
+            this.timerRandomVariation = randomVariation;
             this.serviceFunction = service;
             this.executeOnEachStart = executeOnEachStart;
             this.executeContinuously = executeContinuously;
@@ -128,7 +163,7 @@ namespace PineBT
         {
             // Register the Service as a timer to run infinitly
             if (!this.tree.TreeManager.HasTimer(serviceFunction))
-                this.tree.TreeManager.RegisterTimer(interval, -1, serviceFunction);
+                this.tree.TreeManager.RegisterTimer(interval, timerRandomVariation, -1, serviceFunction);
             if (executeOnEachStart || !initialExecution)
             {
                 serviceFunction.Invoke();


### PR DESCRIPTION
Add random variation to timers and the nodes that use timers. Random variation helps distribute callbacks across frames instead of the same 50 callbacks being executed on the same frame.